### PR TITLE
Add concept of thermal mass and aggregation

### DIFF
--- a/SplitFiles/control.c
+++ b/SplitFiles/control.c
@@ -114,18 +114,22 @@ void execute_command(ControlBuffer *ctrlBuff, GameParameters* params) {
             params->messageAddress = 100 + d - '0';
             BreadState* new_slice = malloc(sizeof(struct BreadStateStruct));
             new_slice->temperature = 0;
+            new_slice->thermalAggregation = 0;
             switch(e) {
                 case 'W':
-                // white bread is driest
+                // white bread is driest and quickest to toast
                 new_slice->moisture = 50 + rand()%50;
+                new_slice->thermalMass = 12350;
                 break;
                 case 'B':
                 // brown takes longer
                 new_slice->moisture = 75 + rand()%60;
+                new_slice->thermalMass = 16384;
                 break;
                 case 'G':
-                // Bagel is a gamble
+                // Bagel is a gamble, and slow
                 new_slice->moisture = 50 + rand()%150;
+                new_slice->thermalMass = 32767;
                 break;
             }
             new_slice->toastedness = 0;

--- a/SplitFiles/control.c
+++ b/SplitFiles/control.c
@@ -119,17 +119,17 @@ void execute_command(ControlBuffer *ctrlBuff, GameParameters* params) {
                 case 'W':
                 // white bread is driest and quickest to toast
                 new_slice->moisture = 50 + rand()%50;
-                new_slice->thermalMass = 12350;
+                new_slice->thermalMass = 62;
                 break;
                 case 'B':
                 // brown takes longer
                 new_slice->moisture = 75 + rand()%60;
-                new_slice->thermalMass = 16384;
+                new_slice->thermalMass = 82;
                 break;
                 case 'G':
                 // Bagel is a gamble, and slow
                 new_slice->moisture = 50 + rand()%150;
-                new_slice->thermalMass = 32767;
+                new_slice->thermalMass = 164;
                 break;
             }
             new_slice->toastedness = 0;

--- a/SplitFiles/control.c
+++ b/SplitFiles/control.c
@@ -48,20 +48,29 @@ char* buffer_getcommand(const char c) {
 }
 
 //show the stack on the screen
-void buffer_restack(const ControlBuffer* const buff) {
+void buffer_restack(ControlBuffer* buff) {
     int i;
     char* command;
-    const int buffer_index = buff->bufferIndex;
+    const int bufferIndex = buff->bufferIndex;
+    int prevBufferIndex = buff->prevBufferIndex;
     // Write out commands
-    printf(PRINTAT"%c%c""%-12s", 18, 12, "Commands");
-    for (i = 0; i < buffer_index; ++i) {
-        command = buffer_getcommand((buff->buffer[i]));
-        printf(PRINTAT"%c%c""%-12s", 18, i + 13, command);
+    if (prevBufferIndex < 0) { //Do this once
+        printf(PRINTAT"%c%c""%-12s", 18, 12, "Commands");
+        prevBufferIndex = 0;
     }
-    // Ensure the rest is cleared
-    for (; i <= CONTROL_BUFFER_SIZE; i++) {
-        printf(PRINTAT"%c%c""%-12s", 18, i + 13, " ");
+    if (prevBufferIndex < bufferIndex) {
+        for (i = prevBufferIndex; i < bufferIndex; ++i) {
+            command = buffer_getcommand((buff->buffer[i]));
+            printf(PRINTAT"%c%c""%-12s", 18, i + 13, command);
+        }
     }
+    if (prevBufferIndex > bufferIndex) {
+        // Ensure the rest is cleared
+        for (i = prevBufferIndex; i >= bufferIndex; --i) {
+            printf(PRINTAT"%c%c""%-12s", 18, i + 13, " ");
+        }
+    }
+    buff->prevBufferIndex = bufferIndex;
 }
 
 int buffer_push(unsigned char c, ControlBuffer* buff) {
@@ -87,6 +96,7 @@ unsigned char buffer_pop(ControlBuffer* buff) {
 
 void initialise_control_buffer(ControlBuffer *buff) {
     buff->bufferIndex = 0;
+    buff->prevBufferIndex = -1;
     buff->lastCharSeen = 0;
     buff->buffer = (unsigned char*)malloc(CONTROL_BUFFER_SIZE * sizeof(unsigned char));
 }

--- a/SplitFiles/control.h
+++ b/SplitFiles/control.h
@@ -11,6 +11,7 @@ static const unsigned int MAX_TICKS = 4096;
 
 struct control_buffer_struct {
     int  bufferIndex;
+    int  prevBufferIndex;
     unsigned char lastCharSeen;
     unsigned char* buffer;
 };

--- a/SplitFiles/game.c
+++ b/SplitFiles/game.c
@@ -130,7 +130,7 @@ int main_game()
       0, //old power
       3, //int       x_coord; //screen x-coord
       5, //int       y_coord; //screen y-coord
-      8192, //thermalMass
+      41, //thermalMass
       0, //thermalAggregation
       (BreadState*) NULL, //bread
       get_slot_monitor(3, 5, 1) //slot monitor

--- a/SplitFiles/game.c
+++ b/SplitFiles/game.c
@@ -144,6 +144,7 @@ int main_game()
     ControlBuffer buff = {
         0,
         0,
+        0,
         NULL
     };
     initialise_control_buffer(&buff);

--- a/SplitFiles/game.c
+++ b/SplitFiles/game.c
@@ -12,9 +12,6 @@
 
 // Compile with:
 // zcc +zx -vn -startup=1 -clib=sdcc_iy -D_TEST_GAME slot.c slot_monitor.c game.c control.c music.c util.c -o game -create-app
-#ifdef _TEST_GAME
-#include "tune_library.c"
-#endif
 
 void draw_tick_line(const unsigned int tick)
 {
@@ -133,6 +130,8 @@ int main_game()
       0, //old power
       3, //int       x_coord; //screen x-coord
       5, //int       y_coord; //screen y-coord
+      8192, //thermalMass
+      0, //thermalAggregation
       (BreadState*) NULL, //bread
       get_slot_monitor(3, 5, 1) //slot monitor
     };

--- a/SplitFiles/music.c
+++ b/SplitFiles/music.c
@@ -7,9 +7,9 @@
 #include "game.h"
 #include "util.h"
 #include "music.h"
-#ifdef _TEST_MUSIC
+//#ifdef _TEST_MUSIC
 #include "tune_library.c"
-#endif
+//#endif
 
 // Can be compiled with:
 // zcc +zx -vn -startup=1 -clib=sdcc_iy -D_TEST_MUSIC music.c -o music -create-app

--- a/SplitFiles/slot.c
+++ b/SplitFiles/slot.c
@@ -19,10 +19,11 @@
 #include "game.h"
 #include "music.h"
 
+#define TMAX 200
+
 void slot_func(GameComponent* input, GameParameters* params) {
   // What does a slot do?
   // Unpack state
-  int breadStateOut = 0;
   SlotState* state = (SlotState*)(input->ptr);
 
   //Check for a message
@@ -37,6 +38,7 @@ void slot_func(GameComponent* input, GameParameters* params) {
     } else {
       //Bread into the slot - let's TOAST!
       state->bread = (BreadState*)params->message;
+      state->power = TMAX;
       params->message = NULL;
       //bit_beepfx(BEEPFX_CLANG);
       params->effect = TUNE_EFFECT_DOWN; 
@@ -58,28 +60,31 @@ void slot_func(GameComponent* input, GameParameters* params) {
   // Now do the toasting thing
   bool update_required = false;
   bool increment = true;
-  if (state->bread) {
+  if (state->power != state->temperature) {
     update_required = true;
-    breadStateOut = 1;
-    state->power = 200; // Slot is on
-    state->temperature += ((state->power - state->temperature) / 10); //temperature may be rising (or steadyish close to 200)
-    state->bread->temperature += ((state->temperature - state->bread->temperature) / 10); //bread temperature also likely to be rising
+    increment = (state->power > state->temperature);
+    // Update the tick-wise integration of observed temperature differences
+    state->thermalAggregation += (state->power - state->temperature);
+    // Calculate new temperature from that
+    state->temperature = (int)(((long)TMAX * state->thermalAggregation) / state->thermalMass);
+#ifdef _TEST_SLOT
+    printf(PRINTAT"\x02\x0B""%d %d %d", state->thermalAggregation, state->temperature, state->power);
+#endif
+  }
+  if (state->bread) {
+    state->bread->thermalAggregation += (state->temperature - state->bread->temperature); //bread temperature also likely to be rising
+    state->bread->temperature = (int)(((long)TMAX * state->bread->thermalAggregation) / state->bread->thermalMass);
     if (state->bread->moisture > 0) {
-      //Dry it out before toastuing can commence
-      state->bread->moisture -= (state->bread->temperature / 10);
+      //Dry it out before toasting can commence
+      state->bread->moisture -= MIN(state->bread->moisture, (state->bread->temperature / 10));
     } else {
       //Can't toast at low temperatures!
       state->bread->toastedness += MAX(0, ((state->bread->temperature - 90) / 10));
     }
+#ifdef _TEST_SLOT
+    printf(PRINTAT"\x02\x0C""%d %d %d %d", state->bread->moisture, state->bread->temperature, state->bread->toastedness, state->bread->thermalAggregation);
+#endif
     params->maxToast = MAX(state->bread->toastedness, params->maxToast);
-  } else {
-    //Cooling - make zero the ambient temp
-    int temp_diff = 0 - (state->temperature / 10);
-    if (temp_diff < 0) {
-      state->temperature += temp_diff;
-      update_required = true;
-      increment = false;
-    }
   }
   if (update_required) {
     state->slotMon->draw_slot(state->slotMon, state, increment);
@@ -97,9 +102,13 @@ int main() {
   SlotState s1state = {
     1, //int       slot_number; // Identifier of this slot
     0, //int       temperature;
+    0,
     0, //int       power;   //Current power level
+    0,
     testMon->xBase, //int       x_coord; //screen x-coord
     testMon->yBase, //int       y_coord; //screen y-coord
+    8192, //thermal mass - quite low for the slot
+    0,    //thermalAggregation
     (BreadState*) NULL, //bread;
     (SlotMonitor *)testMon
   };
@@ -122,19 +131,24 @@ int main() {
 
   BreadState brd = {
     0,
+    0,
     100,
-    0
+    0,
+    0,
+    0,
+    32768, //thermalMass - high for bread
+    0      //thermalAggregation
   };
 
 
   s1state.power = 0;
-  for (i = 0; i < 50; ++i) {
+  for (i = 0; i < 200; ++i) {
     slot_func(&comp, &params);
     s1state.power += 1;
   }
 
   s1state.bread = &brd;
-  for (i = 0; i < 100; ++i) {
+  for (i = 0; i < 500; ++i) {
     slot_func(&comp, &params);
   }
 

--- a/SplitFiles/slot.c
+++ b/SplitFiles/slot.c
@@ -5,7 +5,7 @@
 //////////////////////////////////////////////////////////
 
 // Can be compiled with:
-// zcc +zx -vn -startup=0 -clib=sdcc_iy -D_TEST_SLOT slot.c slot_monitor.c game.c -o slot -create-app
+// zcc +zx -vn -startup=1 -clib=sdcc_iy -D_TEST_SLOT slot.c slot_monitor.c music.c -o slot -create-app
 
 #include <arch/zx.h>
 

--- a/SplitFiles/slot.c
+++ b/SplitFiles/slot.c
@@ -66,14 +66,14 @@ void slot_func(GameComponent* input, GameParameters* params) {
     // Update the tick-wise integration of observed temperature differences
     state->thermalAggregation += (state->power - state->temperature);
     // Calculate new temperature from that
-    state->temperature = (int)(((long)TMAX * state->thermalAggregation) / state->thermalMass);
+    state->temperature = state->thermalAggregation / state->thermalMass;
 #ifdef _TEST_SLOT
     printf(PRINTAT"\x02\x0B""%d %d %d", state->thermalAggregation, state->temperature, state->power);
 #endif
   }
   if (state->bread) {
     state->bread->thermalAggregation += (state->temperature - state->bread->temperature); //bread temperature also likely to be rising
-    state->bread->temperature = (int)(((long)TMAX * state->bread->thermalAggregation) / state->bread->thermalMass);
+    state->bread->temperature = state->bread->thermalAggregation / state->bread->thermalMass;
     if (state->bread->moisture > 0) {
       //Dry it out before toasting can commence
       state->bread->moisture -= MIN(state->bread->moisture, (state->bread->temperature / 10));
@@ -92,9 +92,8 @@ void slot_func(GameComponent* input, GameParameters* params) {
 
 }
 
-#ifdef _TEST_SLOT
 
-int main() {
+int slot_main() {
 
   int i;
   SlotMonitor *testMon = get_slot_monitor(3, 5, 1);
@@ -107,7 +106,7 @@ int main() {
     0,
     testMon->xBase, //int       x_coord; //screen x-coord
     testMon->yBase, //int       y_coord; //screen y-coord
-    8192, //thermal mass - quite low for the slot
+    41, //thermal mass - quite low for the slot
     0,    //thermalAggregation
     (BreadState*) NULL, //bread;
     (SlotMonitor *)testMon
@@ -136,7 +135,7 @@ int main() {
     0,
     0,
     0,
-    32768, //thermalMass - high for bread
+    (unsigned char)164,   //thermalMass - high for bread
     0      //thermalAggregation
   };
 
@@ -155,4 +154,9 @@ int main() {
   return 1;
  
 }
+
+#ifdef _TEST_SLOT
+  int main() {
+    return slot_main();
+  }
 #endif

--- a/SplitFiles/slot_monitor.c
+++ b/SplitFiles/slot_monitor.c
@@ -140,6 +140,8 @@ int main_slot_monitor()
     200,
     15,
     12,
+    8192,
+    0,
     &brd
   };
   for (i = state.temperature; i > 0; --i) {

--- a/SplitFiles/slot_monitor.h
+++ b/SplitFiles/slot_monitor.h
@@ -1,7 +1,6 @@
 #ifndef _DEFINE_SLOT_MONITOR_H
 #define _DEFINE_SLOT_MONITOR_H
 
-
 #include "game.h"
 #include <stdbool.h>
 
@@ -12,6 +11,8 @@ struct BreadStateStruct {
   int      old_moisture;
   int      toastedness;
   int      old_toastedness;
+  unsigned int      thermalMass;
+  unsigned int      thermalAggregation;
 };
 typedef struct BreadStateStruct BreadState;
 
@@ -31,6 +32,8 @@ struct SlotStateStruct {
   int       old_power;
   int       xCoord; //screen x-coord
   int       yCoord; //screen y-coord
+  unsigned int       thermalMass;
+  unsigned int       thermalAggregation;
   BreadState* bread;
   SlotMonitor* slotMon;
 };

--- a/SplitFiles/slot_monitor.h
+++ b/SplitFiles/slot_monitor.h
@@ -11,7 +11,7 @@ struct BreadStateStruct {
   int      old_moisture;
   int      toastedness;
   int      old_toastedness;
-  unsigned int      thermalMass;
+  unsigned char     thermalMass;
   unsigned int      thermalAggregation;
 };
 typedef struct BreadStateStruct BreadState;
@@ -32,7 +32,7 @@ struct SlotStateStruct {
   int       old_power;
   int       xCoord; //screen x-coord
   int       yCoord; //screen y-coord
-  unsigned int       thermalMass;
+  unsigned char      thermalMass;
   unsigned int       thermalAggregation;
   BreadState* bread;
   SlotMonitor* slotMon;


### PR DESCRIPTION
Added thermalMass and thermalAggregation to both slot and bread.  Slows down the heating process for both, making the game a bit more reasonable to play.  Thermal mass will be important for the data-driven bread types.

thermalAgg generally starts at zero, then each loop it adds the temp difference to its environment on.  Once thermalAgg reaches thermalMass _multiplied by the max temperature_, the temp is at the max (200) and so it can't rise any further.  Similarly caps at zero the other end - once the agg is zero it won't find any environment colder. 

Also got the "unit test" for slot working again (ie standalone compile), but this seems to indicate there's a problem with the moisture and toastedness bars in slot monitor.  It may just be that I have screwed up the refresh logic though.