### PR TITLE
Instant controls

### DIFF
--- a/SplitFiles/control.h
+++ b/SplitFiles/control.h
@@ -32,6 +32,8 @@ void initialise_control_buffer(ControlBuffer *buff);
 
 void command_entry_func(GameComponent* input, GameParameters* params);
 
+void command_entry_func_instant(GameComponent* input, GameParameters* params);
+
 //void bread_restack(BreadBin*);
 
 #endif

--- a/SplitFiles/game.c
+++ b/SplitFiles/game.c
@@ -190,7 +190,7 @@ int main_game()
     initialise_control_buffer(&buff);
     GameComponent ctrl = {
         &buff,
-        &command_entry_func,
+        &command_entry_func_instant,
         &slot4
     };
 

--- a/SplitFiles/slot.c
+++ b/SplitFiles/slot.c
@@ -28,7 +28,8 @@ void slot_func(GameComponent* input, GameParameters* params) {
 
   //Check for a message
   int myAddress = 100 + state->slotNumber;
-  if (params->messageAddress == 100 + state->slotNumber) {
+  if (params->messageAddress == 100 + state->slotNumber || 
+        (params->messageAddress == 100 && state->bread == NULL )) {
     //Someone sent bread!
     //Take it off the GameParameters object
     params->messageAddress = 0;


### PR DESCRIPTION
Didn't get much time in the end this weekend, but did manage to test this out.  Worth a playthrough.  This does away with the stack and instead executes each command immediately. W/B/G/C all insert bread of that type in the 'first' available slot (actually they are searched bottom-up right now just due to execution order) while 1/2/3/4 all pop that slot and serve.

This enables full 4-slot play even for a middle aged bloke, and induces a feeling of mild panic even on current settings and with things going well.  I can score around 19,000 and get a happy manager (although that face is being encoded left/right/left/right not right/left/right/left as the other faces are)  If we're going for screen after screen and getting busier day by day, I think we need this change...

Sorry forgot to request a review earlier so this will be behind main