### PR TITLE
Lose Rick and get toast speed a) under control and b) capable of spee…

### DIFF
--- a/SplitFiles/base.c
+++ b/SplitFiles/base.c
@@ -19,6 +19,8 @@ GameParameters* get_game_parameters() {
     params->hotelOpen = 1;     //Open by default
     params->maxCustomers = 6;  //Start with a reasonable cuustomeer queue, goes up each day
     params->minReputation = 0; //Rep needs to go negative initially
+    params->wait_frames = 1;   //Minimum number of frames per cycle
+    params->toast_ticks = 3;   //Toast only gets updated this frequenntly; 1 = all the time
     return params;
 }
 

--- a/SplitFiles/base.h
+++ b/SplitFiles/base.h
@@ -57,6 +57,8 @@ struct GameParameters_Struct {
   int        hotelOpen;  // Are we open for business?
   int        maxCustomers; //How many customers are we allowing now?
   int        minReputation; //How bad do you have to be to get the sack?
+  int        wait_frames;   //Minimum frames per loop
+  int        toast_ticks;   //How often toast is updated
 };
 
 

--- a/SplitFiles/game.c
+++ b/SplitFiles/game.c
@@ -255,9 +255,9 @@ int play_game( GameParameters* params )
   // *******************************************************
 
     //Three-voice music player
-    MusicPlayer* music_player = get_music_player(3);
-    music_player->add_music(music_player, TUNE_TIMING, 2);//Keep speed constant-ish
-    music_player->add_music(music_player, TUNE_RICKROLL, 1);
+    MusicPlayer* music_player = get_music_player(2);
+    //music_player->add_music(music_player, TUNE_TIMING, 2);//Keep speed constant-ish
+    music_player->add_music(music_player, TUNE_DRUM, 1);
     music_player->add_music(music_player, TUNE_EFFECT_BEEP, 0);
     // ****************************************************
     //  Music set-up ends
@@ -341,7 +341,9 @@ int play_game( GameParameters* params )
          params->gameOverFlag == 0 && 
                   (i < MAX_TICKS ||  base.customerCount > 0); //Existing customers should be served (or leave)
          i++) { 
-      int last_frame_count = G_frames;
+      //Ensure we can't get an overrun on frames
+      G_frames_local = 0;
+      int last_frame_count = G_frames_local;
 
       GameComponent* comp = &ticker;
       while (comp) {
@@ -355,7 +357,7 @@ int play_game( GameParameters* params )
         params->effect = NULL;
       }
       //Min one frame per loop
-      while (G_frames == last_frame_count) {}
+      while (G_frames_local < last_frame_count + params->wait_frames) {}
       //printf(PRINTAT"\x12\x14""%d %d %d  ",params->reputation, params->minReputation, params->gameOverFlag);
     }
     if (params->gameOverFlag == 0) {

--- a/SplitFiles/slot.c
+++ b/SplitFiles/slot.c
@@ -67,7 +67,7 @@ void slot_func(GameComponent* input, GameParameters* params) {
     printf(PRINTAT"\x02\x0B""%d %d %d", state->thermalAggregation, state->temperature, state->power);
 #endif
 
-  if (state->bread) {
+  if (state->bread && (params->ticks % params->toast_ticks) == 0) {
     state->bread->thermalAggregation += (state->temperature - state->bread->temperature); //bread temperature also likely to be rising
     state->bread->temperature = state->bread->thermalAggregation / state->bread->thermalMass;
     if (state->bread->moisture > 0) {

--- a/SplitFiles/util.c
+++ b/SplitFiles/util.c
@@ -35,6 +35,7 @@
 // frame counter
 
 unsigned int G_frames = 0;
+unsigned int G_frames_local = 0;
 
 // There are a lot of ways to define an interrupt service routine
 // This one is being done with a macro.  What makes a regular function
@@ -51,6 +52,7 @@ IM2_DEFINE_ISR_8080(isr)
 {
    // update the clock
    ++G_frames;
+   ++G_frames_local;
 }
 
 void start_frame_count() {

--- a/SplitFiles/util.h
+++ b/SplitFiles/util.h
@@ -16,5 +16,6 @@
 // frame counter
 void start_frame_count();
 extern unsigned int G_frames;
+extern unsigned int G_frames_local;
 
 #endif


### PR DESCRIPTION
…ding up

This does a number of things.
 - Gets rid of Rick :-(
 - Puts the Toast drum track back in
 - Creates a second frame counter for loop timing that can be reset to avoid overflow errors but...
 - that approach was unsuccessful - game is less responsive with a high count there, but it might still be useful elsewhere
 - Introduces a "toast ticks" parameter - toast values are only updated with this period (in ticks ie iterations of game loop)
 - Slot values updated continuously so game is smooth, but toasting is slowed down (and can hence be speeded up!)
